### PR TITLE
Funding accounts, defaults from flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "chalk": "1.1.3",
     "inquirer": "3.0.6",
     "lodash.get": "4.4.2",
+    "minimist": "^1.2.0",
     "ripple-lib": "0.17.7"
   }
 }


### PR DESCRIPTION
Fixes problem with `actNotFound` error when funding new accounts.

Usage with flags:

```console
RIPPLE_API=ws://localhost:6065 \
node bin/cmd.js pay \
    --from rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh \
    --secret snoPBrXtMeMyMHUVTgbuqAfg1SUTb \
    --amount 20 \
    --to rNSU4AB43iJSs1LpyejtL7iowFpbT3qEo5
```

Confirmations need to be done for every single value, still very useful for testing purposes.

Thanks.