### PR TITLE
fix "Last X transactions" to actual number of tx's, not limit number

### DIFF
--- a/scripts/balance.js
+++ b/scripts/balance.js
@@ -38,7 +38,7 @@ const getBalance = (address) => {
         }).then(transactions => {
 
           if (transactions.length) {
-            console.log(chalk.yellow(`Last ${limitTransactions} transactions`))
+            console.log(chalk.yellow(`Last ${transactions.length} transactions`))
             transactions.forEach(t => displayRecord(t, address))
             console.log()
           }


### PR DESCRIPTION
Change display of "Last X transactions" to the actual number of transactions found, not the limit number. If the actual number of transactions is fewer than the limit number, this would have displayed a number greater than the actual number of transactions displayed.